### PR TITLE
Fullscreen: keyboard shortcuts + Help update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <title>New Wisk</title>
@@ -52,9 +52,7 @@
                 height: 30px;
                 border-radius: 50%;
                 border: 3.5px solid var(--fg-1);
-                animation:
-                    spinner-bulqg1 0.96s infinite linear alternate,
-                    spinner-oaa3wk 1.92s infinite linear;
+                animation: spinner-bulqg1 0.96s infinite linear alternate, spinner-oaa3wk 1.92s infinite linear;
             }
             @keyframes spinner-bulqg1 {
                 0% {
@@ -184,6 +182,9 @@
                     <div class="nav-top-icons">
                         <button class="nav-button" onclick="toggleMenu()" id="menu-1">
                             <img src="/js/plugins/icons/menu.svg" alt="Menu" class="plugin-icon" />
+                        </button>
+                        <button class="nav-button" onclick="toggleFullscreen()" id="fullscreen-toggle" title="Toggle Fullscreen (F11)">
+                            <img src="/a7/plugins/neo-ai/expand.svg" alt="Fullscreen" class="plugin-icon" />
                         </button>
                     </div>
                     <div class="nav-plugins">

--- a/index.html
+++ b/index.html
@@ -183,9 +183,6 @@
                         <button class="nav-button" onclick="toggleMenu()" id="menu-1">
                             <img src="/js/plugins/icons/menu.svg" alt="Menu" class="plugin-icon" />
                         </button>
-                        <button class="nav-button" onclick="toggleFullscreen()" id="fullscreen-toggle" title="Toggle Fullscreen (F11)">
-                            <img src="/a7/plugins/neo-ai/expand.svg" alt="Fullscreen" class="plugin-icon" />
-                        </button>
                     </div>
                     <div class="nav-plugins">
                         <div class="nav-app">

--- a/js/elements/help-dialog.js
+++ b/js/elements/help-dialog.js
@@ -241,6 +241,13 @@ class HelpDialog extends LitElement {
                         <div style="display: flex; gap: var(--gap-2); flex-direction: column; width: 100%;">
                             <p class="shortcut">Command Palette <span class="shortcut-key">Ctrl + Shift + P</span></p>
                             <p class="shortcut">Search <span class="shortcut-key">Ctrl + Shift + F</span></p>
+                            <p class="shortcut">
+                                <span>Toggle Fullscreen</span>
+                                <span style="display: flex; align-items: center; gap: var(--gap-2);">
+                                    <span class="shortcut-key">F11</span>
+                                    <span class="shortcut-key">Ctrl + ⌘ + F</span>
+                                </span>
+                            </p>
                         </div>
                     </div>
 

--- a/js/plugins/code/options-component.js
+++ b/js/plugins/code/options-component.js
@@ -1427,6 +1427,8 @@ class OptionsComponent extends LitElement {
                             <jalebi-toggle id="toggle-notifications" ?checked="${this.notificationsEnabled}" @valuechange="${this.toggleNotifications}"></jalebi-toggle>
                         </div>
 
+                        
+
                         <!--
                         <div class="menu-item-static content-section">
                             <label for="toggle-autocomplete">AI Autocomplete</label>

--- a/script.js
+++ b/script.js
@@ -150,6 +150,65 @@ const closeApp = () => fetch('/app-nav/close');
 const minimizeApp = () => fetch('/app-nav/minimize');
 const maximizeApp = () => fetch('/app-nav/maximize');
 
+// Fullscreen helpers
+function isFullscreenActive() {
+    return document.fullscreenElement || document.webkitFullscreenElement || document.msFullscreenElement || null;
+}
+
+function requestFullscreenFor(element) {
+    if (element.requestFullscreen) return element.requestFullscreen();
+    if (element.webkitRequestFullscreen) return element.webkitRequestFullscreen();
+    if (element.msRequestFullscreen) return element.msRequestFullscreen();
+}
+
+function exitFullscreen() {
+    if (document.exitFullscreen) return document.exitFullscreen();
+    if (document.webkitExitFullscreen) return document.webkitExitFullscreen();
+    if (document.msExitFullscreen) return document.msExitFullscreen();
+}
+
+function updateFullscreenIcon() {
+    const btn = document.getElementById('fullscreen-toggle');
+    if (!btn) return;
+    const img = btn.querySelector('img');
+    if (!img) return;
+    if (isFullscreenActive()) {
+        img.src = '/a7/plugins/neo-ai/collapse.svg';
+        img.alt = 'Exit Fullscreen';
+        btn.title = 'Exit Fullscreen (Esc)';
+    } else {
+        img.src = '/a7/plugins/neo-ai/expand.svg';
+        img.alt = 'Enter Fullscreen';
+        btn.title = 'Enter Fullscreen (F11)';
+    }
+}
+
+function toggleFullscreen() {
+    const elem = document.documentElement;
+    if (!isFullscreenActive()) {
+        requestFullscreenFor(elem);
+    } else {
+        exitFullscreen();
+    }
+}
+
+document.addEventListener('fullscreenchange', updateFullscreenIcon);
+document.addEventListener('webkitfullscreenchange', updateFullscreenIcon);
+document.addEventListener('MSFullscreenChange', updateFullscreenIcon);
+
+// Keyboard shortcut: F11 or Ctrl+Cmd+F (macOS)
+document.addEventListener('keydown', e => {
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    if (e.key === 'F11') {
+        e.preventDefault();
+        toggleFullscreen();
+    }
+    if (isMac && e.ctrlKey && e.metaKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault();
+        toggleFullscreen();
+    }
+});
+
 // if url contains 55557 then .nav-app display flex
 // for desktop app
 if (window.location.href.includes('55557')) {


### PR DESCRIPTION
**Summary**
Adds a cross‑browser fullscreen toggle via keyboard only and documents the shortcuts in Help. Removes the previously added nav button and any Options UI.

**Changes**
- Keyboard shortcuts:
  - F11 (all browsers)
  - Ctrl + ⌘ + F (macOS)
- Help dialog: adds “Toggle Fullscreen” with keys grouped on the right and spaced using `var(--gap-2)`
- Removes fullscreen button from nav and any Options control
- No backend changes

**Files Touched**
- `script.js`: `toggleFullscreen()` + listeners
- `js/elements/help-dialog.js`: shortcut row layout
- `index.html`: removed nav fullscreen button

**How to Test**
1) Press F11 or Ctrl+⌘+F → toggles fullscreen; Esc exits  
2) Open Help → Shortcuts section shows “Toggle Fullscreen” with both key combos  
3) If changes don’t appear, hard refresh due to service worker caching

**Related**
- Closes #34

**CLA**
I have read and agree to the Contributor License Agreement in `CLA.md`.  
I agree to the CLA.

---