### PR TITLE
Workspace theme independent from document themes

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -544,7 +544,11 @@ async function initEditor(doc) {
         }
     }
 
-    wisk.theme.setTheme(doc.data.config.theme);
+    // Use workspace theme as fallback if document theme is 'default' or empty
+    const docTheme = doc.data.config.theme;
+    const workspaceTheme = wisk.theme.getWorkspaceTheme();
+    const themeToApply = (!docTheme || docTheme === 'default') ? (workspaceTheme || docTheme) : docTheme;
+    wisk.theme.setTheme(themeToApply);
 
     const page = doc.data;
     deletedElements = page.deletedElements;

--- a/js/scripts/home-sidebar.js
+++ b/js/scripts/home-sidebar.js
@@ -76,6 +76,12 @@ function initHomeSidebar() {
 
             themeSelect.addEventListener('change', e => {
                 wisk.theme.setTheme(e.target.value);
+                wisk.theme.setWorkspaceTheme(e.target.value);
+            });
+
+            window.addEventListener('wisk-theme-changed', () => {
+                const currentTheme = wisk.theme.getTheme();
+                themeSelect.value = currentTheme;
             });
 
             // Add search button event listener
@@ -113,6 +119,11 @@ function initHomeSidebar() {
         // Update UI
         document.getElementById('workspace-emoji').textContent = workspace.emoji;
         document.getElementById('workspace-name').textContent = workspace.name;
+
+        // Apply workspace theme
+        if (workspace.theme) {
+            wisk.theme.setTheme(workspace.theme);
+        }
 
         // Workspace header click handler
         const workspaceHeader = document.getElementById('workspace-header');
@@ -296,6 +307,7 @@ function initHomeSidebar() {
                     name: input.value.trim(),
                     emoji: emojiDisplay.textContent,
                     id: window.generateWorkspaceId(),
+                    theme: wisk.theme.getTheme() || 'Light',
                 };
 
                 workspaces.push(newWorkspace);

--- a/js/theme/theme.js
+++ b/js/theme/theme.js
@@ -140,14 +140,6 @@ wisk.theme.getThemeData = function (theme) {
     return wisk.theme.themeObject.themes.find(t => t.name === theme);
 };
 
-window.addEventListener('pageshow', function(event) {
-    if (event.persisted) {
-        // Page was restored from bfcache, re-apply theme from localStorage
-        const savedTheme = localStorage.getItem('webapp-theme') || 'default';
-        wisk.theme.setTheme(savedTheme);
-    }
-});
-
 async function initTheme() {
     const jsonUrl = SERVER + '/js/theme/theme-data.json';
     try {

--- a/js/theme/theme.js
+++ b/js/theme/theme.js
@@ -107,6 +107,31 @@ wisk.theme.getTheme = function () {
     return localStorage.getItem('webapp-theme');
 };
 
+wisk.theme.getWorkspaceTheme = function () {
+    const workspacesData = localStorage.getItem('workspaces');
+    if (!workspacesData) return null;
+
+    const parsed = JSON.parse(workspacesData);
+    const currentWorkspaceId = localStorage.getItem('currentWorkspace');
+    const workspace = parsed.workspaces.find(w => w.id === currentWorkspaceId);
+
+    return workspace?.theme || null;
+};
+
+wisk.theme.setWorkspaceTheme = function (themeName) {
+    const workspacesData = localStorage.getItem('workspaces');
+    if (!workspacesData) return;
+
+    const parsed = JSON.parse(workspacesData);
+    const currentWorkspaceId = localStorage.getItem('currentWorkspace');
+    const workspaceIndex = parsed.workspaces.findIndex(w => w.id === currentWorkspaceId);
+
+    if (workspaceIndex !== -1) {
+        parsed.workspaces[workspaceIndex].theme = themeName;
+        localStorage.setItem('workspaces', JSON.stringify(parsed));
+    }
+};
+
 wisk.theme.getThemes = function () {
     return wisk.theme.themeObject.themes;
 };
@@ -114,6 +139,14 @@ wisk.theme.getThemes = function () {
 wisk.theme.getThemeData = function (theme) {
     return wisk.theme.themeObject.themes.find(t => t.name === theme);
 };
+
+window.addEventListener('pageshow', function(event) {
+    if (event.persisted) {
+        // Page was restored from bfcache, re-apply theme from localStorage
+        const savedTheme = localStorage.getItem('webapp-theme') || 'default';
+        wisk.theme.setTheme(savedTheme);
+    }
+});
 
 async function initTheme() {
     const jsonUrl = SERVER + '/js/theme/theme-data.json';


### PR DESCRIPTION
## Summary
  - Each workspace now stores its own theme preference
  - Switching workspaces automatically applies that workspace's theme
  - Documents use workspace theme as fallback when their theme is "default" or empty
  - New workspaces inherit the current theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace-level theme preferences now persist across sessions
  * Document theme application falls back to workspace theme when not explicitly set
  * Theme selector updates reflect global theme changes in real-time

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->